### PR TITLE
Add unknowns prompt to project planning intake

### DIFF
--- a/project_planning_process.md
+++ b/project_planning_process.md
@@ -18,6 +18,9 @@ To begin a new project, the user should provide the initial information using th
 
 **Key Constraints and Preferences:**
 [List any critical technical constraints (e.g., "must be client-side", "must work offline"), preferred technologies (e.g., "prefer Python", "avoid frameworks"), budgetary constraints (e.g., "must use free services"), or design inspirations.]
+
+**Unknowns & Open Questions:**
+[List gaps in information, unresolved decisions, or outstanding questions that need clarification before planning can proceed.]
 ```
 
 ## 1\. Phase 1: Discovery, Research, and PRD Definition (The "What")


### PR DESCRIPTION
## Summary
- add an "Unknowns & Open Questions" section to the intake brief template in project_planning_process.md
- prompt requesters to capture unresolved decisions or missing information before planning begins

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e374b55f648324b3dae8eb6a568dcf